### PR TITLE
CBD-3262 remove debian8 from cheshire-cat and master since it is no longer built

### DIFF
--- a/couchbase-server/check_builds/pkg_data.json
+++ b/couchbase-server/check_builds/pkg_data.json
@@ -445,12 +445,6 @@
                 "sep1": "-",
                 "sep2": "."
               },
-              "debian8": {
-                "arch": "amd64",
-                "ext": "deb",
-                "sep1": "_",
-                "sep2": "_"
-              },
               "debian9": {
                 "arch": "amd64",
                 "ext": "deb",
@@ -545,12 +539,6 @@
                 "ext": "rpm",
                 "sep1": "-",
                 "sep2": "."
-              },
-              "debian8": {
-                "arch": "amd64",
-                "ext": "deb",
-                "sep1": "_",
-                "sep2": "_"
               },
               "debian9": {
                 "arch": "amd64",


### PR DESCRIPTION
remove debian8 from cheshire-cat and master

-Ming Ho