### PR TITLE
CBD-3109: Add beta yum/apt repositories

### DIFF
--- a/couchbase-server/repo_upload/README.md
+++ b/couchbase-server/repo_upload/README.md
@@ -1,9 +1,9 @@
 # Notice
 
-The files `apt.json` and `yum.json` are referenced by:
+At time of writing, the files `apt.json` and `yum.json` are referenced by:
 
 - [check_cowbuilder_distros](https://github.com/couchbase/build-infra/blob/master/docker/buildslaves/sdk/cowbuilder/jenkins/check_cowbuilder_distros.sh#L12)
-- [couchbase-release](https://github.com/couchbase/build-tools/blob/master/couchbase-release/go.sh#L33-L45)
+- [couchbase-release](https://github.com/couchbase/build-tools/blob/681a3e3683d33218d4644ce037addf07dab61bfe/couchbase-release/go.sh#L33-L45)
 - [repo_upload/apt](https://github.com/couchbase/build-tools/blob/681a3e3683d33218d4644ce037addf07dab61bfe/repo_upload/repo_upload/repos/apt.py#L41-L45)
 - [repo_upload/yum](https://github.com/couchbase/build-tools/blob/681a3e3683d33218d4644ce037addf07dab61bfe/repo_upload/repo_upload/repos/yum.py#L49-L55)
 

--- a/couchbase-server/repo_upload/README.md
+++ b/couchbase-server/repo_upload/README.md
@@ -1,0 +1,10 @@
+# Notice
+
+The files `apt.json` and `yum.json` are referenced by:
+
+- [check_cowbuilder_distros](https://github.com/couchbase/build-infra/blob/master/docker/buildslaves/sdk/cowbuilder/jenkins/check_cowbuilder_distros.sh#L12)
+- [couchbase-release](https://github.com/couchbase/build-tools/blob/master/couchbase-release/go.sh#L33-L45)
+- [repo_upload/apt](https://github.com/couchbase/build-tools/blob/681a3e3683d33218d4644ce037addf07dab61bfe/repo_upload/repo_upload/repos/apt.py#L41-L45)
+- [repo_upload/yum](https://github.com/couchbase/build-tools/blob/681a3e3683d33218d4644ce037addf07dab61bfe/repo_upload/repo_upload/repos/yum.py#L49-L55)
+
+Please make any updates necessary to the relevant scripts if you are changing the structure of the data in these files.

--- a/couchbase-server/repo_upload/base.json
+++ b/couchbase-server/repo_upload/base.json
@@ -1,6 +1,5 @@
 {
   "editions": [
-    "beta",
     "community",
     "enterprise"
   ],
@@ -67,18 +66,6 @@
       "development": [
         "6.6.1",
         "7.0.0"
-      ]
-    },
-    "beta": {
-      "released": [
-        "4.0.0-beta",
-        "4.5.0-beta",
-        "5.0.0-beta",
-        "5.0.0-beta2",
-        "5.5.0-beta",
-        "6.0.0-beta",
-        "6.5.0-beta",
-        "6.5.0-beta2"
       ]
     }
   }

--- a/couchbase-server/repo_upload/beta.json
+++ b/couchbase-server/repo_upload/beta.json
@@ -1,0 +1,37 @@
+{
+  "editions": [
+    "community",
+    "enterprise"
+  ],
+  "gpg_keys": [
+    "79CF7903.priv.gpg",
+    "CD406E62.priv.gpg",
+    "D9223EDA.priv.gpg"
+  ],
+  "supported_releases": {
+    "enterprise": {
+      "released": [
+        "4.0.0-beta",
+        "4.5.0-beta",
+        "5.0.0-beta",
+        "5.0.0-beta2",
+        "5.5.0-beta",
+        "6.0.0-beta",
+        "6.5.0-beta",
+        "6.5.0-beta2"
+      ]
+    },
+    "community": {
+      "released": [
+        "4.0.0-beta",
+        "4.5.0-beta",
+        "5.0.0-beta",
+        "5.0.0-beta2",
+        "5.5.0-beta",
+        "6.0.0-beta",
+        "6.5.0-beta",
+        "6.5.0-beta2"
+      ]
+    }
+  }
+}

--- a/couchbase-server/repo_upload/beta.json
+++ b/couchbase-server/repo_upload/beta.json
@@ -11,24 +11,12 @@
   "supported_releases": {
     "enterprise": {
       "released": [
-        "4.0.0-beta",
-        "4.5.0-beta",
-        "5.0.0-beta",
-        "5.0.0-beta2",
-        "5.5.0-beta",
-        "6.0.0-beta",
         "6.5.0-beta",
         "6.5.0-beta2"
       ]
     },
     "community": {
       "released": [
-        "4.0.0-beta",
-        "4.5.0-beta",
-        "5.0.0-beta",
-        "5.0.0-beta2",
-        "5.5.0-beta",
-        "6.0.0-beta",
         "6.5.0-beta",
         "6.5.0-beta2"
       ]


### PR DESCRIPTION
This change is to facilitate CE betas (and provide some clarifying information about metadata usage)