### PR TITLE
add "unsigned" to alice's macosx package name.

### DIFF
--- a/couchbase-server/check_builds/pkg_data.json
+++ b/couchbase-server/check_builds/pkg_data.json
@@ -272,7 +272,7 @@
                 "sep2": "_"
               },
               "macos": {
-                "arch": "x86_64",
+                "arch": "x86_64-unsigned",
                 "ext": "zip",
                 "sep1": "_",
                 "sep2": "_"


### PR DESCRIPTION
check for "couchbase-server-<edition>_<version>-<bld>-macos_x86_64-unsigned.zip" 
instead of "couchbase-server-<edition>_<version>-<bld>-macos_x86_64.zip"

-Ming Ho