### PR TITLE
add SGW 3.0.0 to missing commit check.

### DIFF
--- a/sync_gateway/missing_commits/3.0.0/ok-missing-commits.txt
+++ b/sync_gateway/missing_commits/3.0.0/ok-missing-commits.txt
@@ -1,0 +1,3 @@
+sync_gateway 2c556d1 
+sync_gateway 5f0417c 
+sync_gateway e78dbf1 

--- a/sync_gateway/missing_commits/3.0.0/previous-manifests.txt
+++ b/sync_gateway/missing_commits/3.0.0/previous-manifests.txt
@@ -1,0 +1,2 @@
+manifest/2.8.xml
+manifest/2.7.xml


### PR DESCRIPTION
add SGW 3.0.0 so that check_missing_commits job can check latest release instead of 2.1.0

-Ming Ho