### PR TITLE
fixed lite-c macosx check.

### DIFF
--- a/couchbase-lite-c/check_builds/pkg_data.json
+++ b/couchbase-lite-c/check_builds/pkg_data.json
@@ -22,7 +22,7 @@
               "ios": {
                 "ext": "zip"
               },
-              "macosx": {
+              "macosx-x86_64": {
                 "ext": "zip"
               },
               "raspbian9": {


### PR DESCRIPTION
fixed lite-c macosx check.  look for macosx-x86_64.zip instead of macosx.zip

-Ming Ho