### PR TITLE
Change macosx-x86_64 to macos to reflect new architecture added

### DIFF
--- a/couchbase-lite-c/check_builds/pkg_data.json
+++ b/couchbase-lite-c/check_builds/pkg_data.json
@@ -22,7 +22,7 @@
               "ios": {
                 "ext": "zip"
               },
-              "macosx-x86_64": {
+              "macos": {
                 "ext": "zip"
               },
               "raspbian9": {


### PR DESCRIPTION
And also finally get rid of the outdated 'macosx' moniker