### PR TITLE
Fix list of Windows artifacts in core check_builds

### DIFF
--- a/couchbase-lite-core/check_builds/pkg_data.yaml.j2
+++ b/couchbase-lite-core/check_builds/pkg_data.yaml.j2
@@ -5,7 +5,7 @@
 {##}
 {%
   set platforms_for = {
-    (3, 1, 0):   [ "android-arm64-v8a", "android-armeabi-v7a", "android-x86", "android-x86_64", "ios", "linux", "macosx", "windows-arm-store", "windows-win32-store", "windows-win32", "windows-win64-store", "windows-win64"]
+    (3, 1, 0):   [ "android-arm64-v8a", "android-armeabi-v7a", "android-x86", "android-x86_64", "ios", "linux", "macosx", "windows-win64-store", "windows-win64", "windows-arm64-store", "windows-arm64"]
   }
 %}
 


### PR DESCRIPTION
Remove 32-bit ARM/x86, add 64-bit ARM