### PR TITLE
CBD-5202, move SGW package info from sync-gateway to sync_gateway

### DIFF
--- a/sync_gateway/check_builds/pkg_data.yaml.j2
+++ b/sync_gateway/check_builds/pkg_data.yaml.j2
@@ -22,7 +22,9 @@
     "2.6.0":   [ "debian", "redhat", "windows"],
     "2.7.4":   [ "debian", "redhat", "windows", "macos"],
     "2.8.0":   [ "debian", "redhat", "windows", "macos"],
-    "3.0.0":   [ "debian", "redhat", "windows", "macos", "macos:arm64", "amzn2:aarch64" ]
+    "3.0.0":   [ "debian", "redhat", "windows", "macos", "macos:arm64", "amzn2:aarch64" ],
+    "3.0.4":   [ "debian", "redhat", "windows", "macos", "macos:arm64", "amzn2:aarch64", "debian:aarch64" ],
+    "3.1.0":   [ "debian", "redhat", "windows", "macos", "macos:arm64", "amzn2:aarch64", "debian:aarch64" ]
   }
 %}
 


### PR DESCRIPTION
CBD-5202, latest check_builds is doing the right thing now.
It looks under sync_gateway instead of sync-gateway.  Hence, move the file over.

-Ming Ho