### PR TITLE
CBD-5202, fix SGW check_builds.

### DIFF
--- a/sync_gateway/check_builds/pkg_data.yaml.j2
+++ b/sync_gateway/check_builds/pkg_data.yaml.j2
@@ -89,7 +89,7 @@ filenames:
 {%    endif                                        %}
 {%    for edition in [ "community", "enterprise" ] %}
 
-  - {{ product }}-{{ edition }}{{ bits["sep1"] }}{{ version }}-{{ build_num }}{{ bits["sep2"] }}{{ arch }}.{{ bits["ext"] }}
+  - couchbase-sync-gateway-{{ edition }}{{ bits["sep1"] }}{{ version }}-{{ build_num }}{{ bits["sep2"] }}{{ arch }}.{{ bits["ext"] }}
 
 {%    endfor %}
 {% endfor %}


### PR DESCRIPTION
The package name is incorrectly formatted.

-Ming Ho