### PR TITLE
Set lite-core platforms for 3.2.0

### DIFF
--- a/couchbase-lite-core/check_builds/pkg_data.yaml.j2
+++ b/couchbase-lite-core/check_builds/pkg_data.yaml.j2
@@ -5,7 +5,8 @@
 {##}
 {%
   set platforms_for = {
-    (3, 1, 0):   [ "android-arm64-v8a", "android-armeabi-v7a", "android-x86", "android-x86_64", "ios", "linux", "macosx", "windows-win64-store", "windows-win64", "windows-arm64-store", "windows-arm64"]
+    (3, 1, 0):   [ "android-arm64-v8a", "android-armeabi-v7a", "android-x86", "android-x86_64", "ios", "linux", "macosx", "windows-win64-store", "windows-win64", "windows-arm64-store", "windows-arm64"],
+    (3, 2, 0):   [ "android-arm64-v8a", "android-armeabi-v7a", "android-x86", "android-x86_64", "ios", "linux", "macosx", "windows-win64", "windows-arm64"]
   }
 %}
 


### PR DESCRIPTION
Removed "store" variants