### PR TITLE
CBD-6368: Add missing container info

### DIFF
--- a/couchbase-edge-server/containers/image_info.json
+++ b/couchbase-edge-server/containers/image_info.json
@@ -5,6 +5,6 @@
     ],
     "absences": [{"registry": "rhcc"}],
     "build_jobs": {
-            "dockerhub": "couchbase-k8s-microservice-republish"
+            "dockerhub": "update-dockerhub"
     }
 }

--- a/couchbase-edge-server/containers/image_info.json
+++ b/couchbase-edge-server/containers/image_info.json
@@ -1,0 +1,10 @@
+{
+    "github_repo": "couchbase/edge-server",
+    "editions": [
+        "enterprise"
+    ],
+    "absences": [{"registry": "rhcc"}],
+    "build_jobs": {
+            "dockerhub": "couchbase-k8s-microservice-republish"
+    }
+}

--- a/couchbase-edge-server/lifecycle_dates.json
+++ b/couchbase-edge-server/lifecycle_dates.json
@@ -1,0 +1,5 @@
+{
+    "1.0": {
+        "generally_available": "2025-03"
+    }
+}

--- a/couchbase-elasticsearch-connector/containers/image_info.json
+++ b/couchbase-elasticsearch-connector/containers/image_info.json
@@ -4,7 +4,6 @@
         "enterprise"
     ],
     "build_jobs": {
-            "dockerhub": "update-dockerhub",
-            "rhcc": "update-rhcc"
+            "dockerhub": "couchbase-k8s-microservice-republish"
     }
 }

--- a/couchbase-elasticsearch-connector/containers/image_info.json
+++ b/couchbase-elasticsearch-connector/containers/image_info.json
@@ -1,5 +1,5 @@
 {
-    "github_repo": "couchbase/docker",
+    "github_repo": "couchbase/couchbase-elasticsearch-connector",
     "editions": [
         "enterprise"
     ],

--- a/couchbase-elasticsearch-connector/containers/image_info.json
+++ b/couchbase-elasticsearch-connector/containers/image_info.json
@@ -1,0 +1,10 @@
+{
+    "github_repo": "couchbase/docker",
+    "editions": [
+        "enterprise"
+    ],
+    "build_jobs": {
+            "dockerhub": "update-dockerhub",
+            "rhcc": "update-rhcc"
+    }
+}

--- a/couchbase-elasticsearch-connector/containers/image_info.json
+++ b/couchbase-elasticsearch-connector/containers/image_info.json
@@ -3,6 +3,7 @@
     "editions": [
         "enterprise"
     ],
+    "absences": [{"registry": "rhcc"}],
     "build_jobs": {
             "dockerhub": "couchbase-k8s-microservice-republish"
     }

--- a/couchbase-elasticsearch-connector/lifecycle_dates.json
+++ b/couchbase-elasticsearch-connector/lifecycle_dates.json
@@ -1,0 +1,5 @@
+{
+    "4.4": {
+        "generally_available": "2022-07"
+    }
+}

--- a/couchbase-fluent-bit/containers/image_info.json
+++ b/couchbase-fluent-bit/containers/image_info.json
@@ -1,7 +1,7 @@
 {
     "github_repo": "couchbase/couchbase-fluent-bit",
     "build_jobs": {
-            "dockerhub": "couchbase-k8s-microservice-republish",
-            "rhcc": "couchbase-k8s-microservice-republish"
+        "dockerhub": "couchbase-k8s-microservice-republish",
+        "rhcc": "couchbase-k8s-microservice-republish"
     }
 }


### PR DESCRIPTION
Adds the relevant container metadata for edge-server and es-connector.